### PR TITLE
fix first time setup issue with path resolution in setup script

### DIFF
--- a/deno/local-setup.sh
+++ b/deno/local-setup.sh
@@ -50,6 +50,6 @@ if [ ! -f "$localdir/bin/deno" ]; then
 fi
 
 # Now use a deno script to install all other local tooling
-deno run --quiet --unstable --allow-all $reporoot/deno/local-setup.ts $denoversion $localdir
+$localbin/deno run --quiet --unstable --allow-all $reporoot/deno/local-setup.ts $denoversion $localdir
 source $localdir/bin/local-env.sh
 


### PR DESCRIPTION
I'm not sure if this is the right fix but this modification helps `. deno/local-setup.sh` resolve the correct deno on a fresh install (it works the second try).

Within the script, `which deno` resolves to the newly downloaded local binary but invoking `deno` still uses one from my global path. 