### PR TITLE
minor dev improvements

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,14 +1,14 @@
 {
     "lock": "./deno/deno.lock",
     "tasks" : {
-      "genadl" : "deno run --check=all --allow-all deno/genadl.ts && cd ts && pnpm install",
+      "genadl" : "deno run --quiet --check=all --allow-all deno/genadl.ts && cd ts && pnpm install",
       "build-server-image": "cd rust/server && docker build --tag protoapp-server:latest .",
       "build-ui-image": "cd ts/ui && docker build --file Dockerfile --tag protoapp-ui:latest .."
     },
     "imports": {
       "@adllang/local-setup": "jsr:@adllang/local-setup@^0.16.0",
       "@adllang/adl-runtime": "jsr:@adllang/adl-runtime@^0.1.0",
-      "@adllang/adlc-tools": "jsr:@adllang/adlc-tools@^0.1.4",
+      "@adllang/adlc-tools": "jsr:@adllang/adlc-tools@^0.1.5",
       "@mesqueeb/case-anything": "jsr:@mesqueeb/case-anything@^3.1.0",
       "@std/path": "jsr:@std/path@^1.0.8",
       "mustache_ts": "https://deno.land/x/mustache_ts@v0.4.1.1/mustache.ts"

--- a/deno/deno.lock
+++ b/deno/deno.lock
@@ -1,14 +1,14 @@
 {
   "version": "4",
   "specifiers": {
-    "jsr:@adllang/adl-runtime@0.1": "0.1.0",
-    "jsr:@adllang/adlc-tools@~0.1.4": "0.1.4",
-    "jsr:@adllang/jsonbinding@~0.2.3": "0.2.3",
+    "jsr:@adllang/adl-runtime@0.1": "0.1.2",
+    "jsr:@adllang/adlc-tools@~0.1.5": "0.1.5",
+    "jsr:@adllang/jsonbinding@~0.2.3": "0.2.4",
     "jsr:@adllang/local-setup@0.16": "0.16.0",
     "jsr:@mesqueeb/case-anything@^3.1.0": "3.1.0",
     "jsr:@std/bytes@^1.0.2": "1.0.4",
-    "jsr:@std/encoding@^1.0.5": "1.0.5",
-    "jsr:@std/fs@^1.0.5": "1.0.6",
+    "jsr:@std/encoding@^1.0.5": "1.0.9",
+    "jsr:@std/fs@^1.0.5": "1.0.16",
     "jsr:@std/io@0.225": "0.225.0",
     "jsr:@std/path@^1.0.8": "1.0.8"
   },
@@ -20,8 +20,15 @@
         "jsr:@std/encoding"
       ]
     },
-    "@adllang/adlc-tools@0.1.4": {
-      "integrity": "b4ad076b668b634886511f7ccba829f8bf16602a4f1762dd94ce26c87d9f84b1",
+    "@adllang/adl-runtime@0.1.2": {
+      "integrity": "ed4201074bcab14c644166e1a958f59ce858a09296181e3671245da19eac302c",
+      "dependencies": [
+        "jsr:@adllang/jsonbinding",
+        "jsr:@std/encoding"
+      ]
+    },
+    "@adllang/adlc-tools@0.1.5": {
+      "integrity": "a284b0909a4daaab151207cd3bb60f767b3473e6deddeb65137df436fa9854ed",
       "dependencies": [
         "jsr:@adllang/adl-runtime",
         "jsr:@std/fs",
@@ -30,6 +37,9 @@
     },
     "@adllang/jsonbinding@0.2.3": {
       "integrity": "7206e24c31290b3572c00f2e9039dbce29b3a36ca616256337eafbcdf364d7fa"
+    },
+    "@adllang/jsonbinding@0.2.4": {
+      "integrity": "e179c359ff9a8b2e4b06f7370a72447a2dd018df443ed4bb19181d5d6d2869f2"
     },
     "@adllang/local-setup@0.16.0": {
       "integrity": "6b9d4f12a3b3077fcf2b9b98cd7c031fe2f275d017a12222b2005cd4a11a761b",
@@ -48,8 +58,17 @@
     "@std/encoding@1.0.5": {
       "integrity": "ecf363d4fc25bd85bd915ff6733a7e79b67e0e7806334af15f4645c569fefc04"
     },
+    "@std/encoding@1.0.9": {
+      "integrity": "025b8f18eb1749bc30d1353bf48b77d1eb5e35610220fa226f5a046b9240c5d7"
+    },
     "@std/fs@1.0.6": {
       "integrity": "42b56e1e41b75583a21d5a37f6a6a27de9f510bcd36c0c85791d685ca0b85fa2",
+      "dependencies": [
+        "jsr:@std/path"
+      ]
+    },
+    "@std/fs@1.0.16": {
+      "integrity": "81878f62b6eeda0bf546197fc3daa5327c132fee1273f6113f940784a468b036",
       "dependencies": [
         "jsr:@std/path"
       ]
@@ -208,7 +227,7 @@
   "workspace": {
     "dependencies": [
       "jsr:@adllang/adl-runtime@0.1",
-      "jsr:@adllang/adlc-tools@~0.1.4",
+      "jsr:@adllang/adlc-tools@~0.1.5",
       "jsr:@adllang/local-setup@0.16",
       "jsr:@mesqueeb/case-anything@^3.1.0",
       "jsr:@std/path@^1.0.8"

--- a/deno/genadl.ts
+++ b/deno/genadl.ts
@@ -1,5 +1,5 @@
 import * as path from "@std/path";
-import { genRust, genTypescript } from "@adllang/adlc-tools";
+import { AdlcError, genRust, genTypescript } from "@adllang/adlc-tools";
 
 import { genAdlTsPackage } from "./gen-adl-ts-package.ts";
 import { genCreateSqlSchema } from "./gen-sqlschema.ts";
@@ -93,4 +93,13 @@ export function getRepoRoot(): string {
   return path.dirname(path.dirname(modulepath));
 }
 
-await main();
+try {
+  await main();
+} catch (e: unknown) {
+  if (e instanceof AdlcError && e.showTraceback === false) {
+    console.error(e.message);
+  } else {
+    console.error(e);
+  }
+  Deno.exit(1);
+}

--- a/deno/genadl.ts
+++ b/deno/genadl.ts
@@ -93,6 +93,4 @@ export function getRepoRoot(): string {
   return path.dirname(path.dirname(modulepath));
 }
 
-main().catch((err) => {
-  console.error("error in main", err);
-});
+await main();

--- a/rust/rust-toolchain.toml
+++ b/rust/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 channel = "1.85.1"
-components = ["clippy", "rustfmt"]
+components = ["clippy", "rustfmt", "rust-analyzer"]


### PR DESCRIPTION
install rust-analyser with toolchain

ensure that genadl.ts has exit status 1 on failure so that the subsequent ts builds don't run unnecessarily.

In the face of ADL compilation errors you still get a fair bit of noise eg:

```
In module protoapp.apis.ui :
undefined type LoginRe
error: Uncaught (in promise) Error: Failed to run cmd: adlc typescript --outputdir /home/timd/personal/repos/adl-lang/protoapp/ts/adl/src --manifest /home/timd/personal/repos/adl-lang/protoapp/ts/adl/src/.adl-manifest --generate-transitive --ts-style tsc --include-resolver --excluded-ast-annotations  --searchdir /home/timd/personal/repos/adl-lang/protoapp/.local/lib/adl --searchdir /home/timd/personal/repos/adl-lang/protoapp/adl /home/timd/personal/repos/adl-lang/protoapp/adl/protoapp/apis/ui.adl /home/timd/personal/repos/adl-lang/protoapp/.local/lib/adl/sys/adlast.adl /home/timd/personal/repos/adl-lang/protoapp/adl/common/ui.adl
    throw new Error(`Failed to run cmd: ${cmd} ${args.join(' ')}`);
          ^
    at exec (https://jsr.io/@adllang/adlc-tools/0.1.4/utils/exec.ts:7:11)
    at eventLoopTick (ext:core/01_core.js:178:7)
    at async execAdlc (https://jsr.io/@adllang/adlc-tools/0.1.4/utils/exec.ts:12:3)
    at async main (file:///home/timd/personal/repos/adl-lang/protoapp/deno/genadl.ts:21:5)
    at async file:///home/timd/personal/repos/adl-lang/protoapp/deno/genadl.ts:96:1
```

whereas it would be nice to just have this:

```
In module protoapp.apis.ui :
undefined type LoginRe
```

But in problems with the typescript generation code itself, its nice to have the traceback. Ideally, would detect different failure modes, but for now will leave traceback in.
