### PR TITLE
use 401 for expired or malformed tokens

### DIFF
--- a/rust/server/src/server/poem_adl_interop.rs
+++ b/rust/server/src/server/poem_adl_interop.rs
@@ -199,13 +199,17 @@ fn claims_from_bearer_token(
     let jwt = jwt::bearer_token_from_auth_header(auth_header).ok_or(forbidden())?;
     let claims = jwt::decode_access(jwt_secret, &jwt).map_err(|e| {
         log::error!("failed to validate jwt: {}", e);
-        forbidden()
+        unauthorized()
     })?;
     Ok(claims)
 }
 
 pub fn forbidden() -> HandlerError {
     HandlerError::Poem(poem::Error::from_status(StatusCode::FORBIDDEN))
+}
+
+pub fn unauthorized() -> HandlerError {
+    HandlerError::Poem(poem::Error::from_status(StatusCode::UNAUTHORIZED))
 }
 
 //---------------------------------------------------------------------------

--- a/rust/server/src/server/poem_adl_interop.rs
+++ b/rust/server/src/server/poem_adl_interop.rs
@@ -196,7 +196,7 @@ fn claims_from_bearer_token(
     jwt_secret: &str,
     auth_header: &str,
 ) -> HandlerResult<jwt::AccessClaims> {
-    let jwt = jwt::bearer_token_from_auth_header(auth_header).ok_or(forbidden())?;
+    let jwt = jwt::bearer_token_from_auth_header(auth_header).ok_or(unauthorized())?;
     let claims = jwt::decode_access(jwt_secret, &jwt).map_err(|e| {
         log::error!("failed to validate jwt: {}", e);
         unauthorized()


### PR DESCRIPTION
Allows frontend to use 401 as a trigger for requesting new token or prompting user to login.
403s suggest developer error in frontend, i.e. the app should not allow users to hit endpoints they don't have the right role for.

whilst this weakens the "all requests are 200, errors are checked in userland" rule, it would be handled once centrally in an app. 