### PR TITLE
VS Code improvements + Rust server nit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .local/
+.vscode/.zshcompdump
+.vscode/.zshcompdump.zwc

--- a/.vscode/.zshrc
+++ b/.vscode/.zshrc
@@ -1,0 +1,12 @@
+# Source the user's normal .zshrc first
+if [ -f "$HOME/.zshrc" ]; then
+  source "$HOME/.zshrc"
+fi
+
+# Keep history in the normal location
+export HISTFILE="$HOME/.zsh_history"
+
+# Source the local setup script
+if [ -f "$PWD/deno/local-setup.sh" ]; then
+  . "$PWD/deno/local-setup.sh"
+fi 

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,8 @@
+{
+  "recommendations": [
+    "dbaeumer.vscode-eslint",
+    "denoland.vscode-deno",
+    "esbenp.prettier-vscode",
+    "rust-lang.rust-analyzer"
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,5 +2,19 @@
   "deno.enable": true,
   "deno.enablePaths": ["deno"],
   "deno.path": "./.local/bin/deno",
-  "deno.importMap": "./deno.json"
+  "deno.importMap": "./deno.json",
+  "typescript.preferences.importModuleSpecifier": "non-relative",
+  "terminal.integrated.profiles.osx": {
+    "zsh (local-setup)": {
+      "path": "zsh",
+      "args": ["-i"],
+      "env": {
+        "ZDOTDIR": "${workspaceFolder}/.vscode",
+        "ZSH_COMPDUMP": "${workspaceFolder}/.vscode/.zshcompdump",
+      },
+      "icon": "terminal-bash"
+    }
+  },
+  "terminal.integrated.defaultProfile.osx": "zsh (local-setup)",
+  "terminal.integrated.shellIntegration.enabled": true
 }

--- a/rust/server/src/bin/protoapp-server.rs
+++ b/rust/server/src/bin/protoapp-server.rs
@@ -13,10 +13,11 @@ async fn main() {
 
     match res {
         Err(e) => {
-            eprintln!("Error: {e}");
+            log::error!("server exited with error: {e}");
             std::process::exit(1);
         }
         Ok(_) => {
+            log::info!("server exited successfully");
             std::process::exit(0);
         }
     }
@@ -35,7 +36,7 @@ async fn run() -> anyhow::Result<()> {
         .map_err(|e| anyhow::anyhow!("unable to parse config file: {}", e))?;
 
     inject_secrets(&mut config)?;
-    server::run(config).await;
+    server::run(config).await?;
     Ok(())
 }
 

--- a/rust/server/src/server/mod.rs
+++ b/rust/server/src/server/mod.rs
@@ -30,7 +30,7 @@ impl AppState {
         }
     }
 }
-pub async fn run(config: ServerConfig) {
+pub async fn run(config: ServerConfig) -> Result<(), std::io::Error> {
     let db = &config.db;
 
     let db_connection_url = format!(
@@ -56,7 +56,7 @@ pub async fn run(config: ServerConfig) {
     let addr = &app_state.config.http_bind_addr;
     let server = poem::Server::new(TcpListener::bind(addr)).run(ep);
     log::info!("Listening on http://{}", addr);
-    let _ = server.await;
+    server.await
 }
 
 /**


### PR DESCRIPTION
Two unrelated commits:

QoL in VS Code
- Recommended extensions for LSP to work properly in Deno, Rust and Typescript (last outstanding nit is to have `deno fmt` run on save in the deno subdir rather than prettier)
- Default to non-relative imports in the ts subdir. Promotes consistency and since we have the aliases set up anyway, makes it easier to refactor/move files around. 
- Integrated VS Code terminal opens with the local tooling in $PATH (don't need to remember run `. deno/local-setup.sh`)

Rust server nit:
- Bubble up fatal errors in the server and print them (previously silently failing on errors e.g. if port was already taken)